### PR TITLE
Feat: show a spinner while navigation

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -2,10 +2,17 @@
 	import Header from '../compnonents/shared/Header.svelte';
 	import Footer from '../compnonents/shared/Footer.svelte';
 	import '../app.postcss';
+	import { navigating } from '$app/stores';
+	import { Spinner } from 'flowbite-svelte';
 </script>
 
 <Header />
-<main>
+<main class={$navigating ? 'blur-sm' : ''}>
 	<slot />
 </main>
+
+{#if $navigating}
+	<Spinner class="fixed top-[50%] left-[50%]" />
+{/if}
+
 <Footer />


### PR DESCRIPTION
This PR blurs the whole page and shows a spinner while navigation.
E.g. when the user clicks on another page and this page's load function is running.
![image](https://user-images.githubusercontent.com/30153207/214568103-f1febbe9-13e7-41f9-9068-9635de2f1b52.png)
