### PR TITLE
Fix: competitions missing in calendar

### DIFF
--- a/src/compnonents/competitions/CompetitionCalendar.svelte
+++ b/src/compnonents/competitions/CompetitionCalendar.svelte
@@ -100,7 +100,7 @@
 		}
 	}
 	$: {
-		if (!isMounted() || !isPromise(competitions)) break $;
+		if (!isMounted() || !(competitions instanceof Promise)) break $;
 		handleToggleCalendar(false);
 		competitions.then((comps) => {
 			updateCalendarEvents(comps);

--- a/src/compnonents/competitions/CompetitionCalendar.svelte
+++ b/src/compnonents/competitions/CompetitionCalendar.svelte
@@ -5,7 +5,6 @@
 	import { onMount } from 'svelte';
 	import { stringToHex } from '../../utils/stringToHex';
 	import { mounted } from '../../utils/mounted';
-	import { isPromise } from '../../utils/typeguards';
 	import CalendarSubscriptionModal from './CalendarSubscriptionModal.svelte';
 
 	export let competitions: Competition[] | Promise<Competition[]>;
@@ -63,11 +62,15 @@
 				}
 			}
 		});
-		if (isPromise(competitions)) {
+
+		if (competitions instanceof Promise) {
 			competitions.then((comps) => {
 				updateCalendarEvents(comps);
 			});
+		} else {
+			updateCalendarEvents(competitions);
 		}
+
 		calendar.render();
 	});
 

--- a/src/utils/typeguards.ts
+++ b/src/utils/typeguards.ts
@@ -1,7 +1,0 @@
-import type { Competition } from 'src/types/Competition';
-
-export function isPromise(
-	value: Competition[] | Promise<Competition[]>
-): value is Promise<Competition[]> {
-	return Object.prototype.toString.call(value) === '[object Promise]';
-}


### PR DESCRIPTION
Currently, the competitions do not show up when the load is completed before the calendar is opened. This PR fixes that.